### PR TITLE
Minor fix for a bug on Safari for name/creator name validation

### DIFF
--- a/src/ui/components/Input.ts
+++ b/src/ui/components/Input.ts
@@ -16,8 +16,8 @@ export function Input(
       if (validate)
         if (validate(value)) {
           input.classOff("invalid");
-          callback(value);
           if (editor) editor.errors.set(label, false);
+          callback(value);
         } else {
           input.classOn("invalid");
           if (editor) editor.errors.set(label, true);


### PR DESCRIPTION
For whatever reason, on Safari, if you enter an invalid name/creator name, it will forever be marked as invalid and won't let you save no matter what, and this PR addresses that.

I traced the function I modified and the execution.. stops? when it reaches the line: `callback(value);` - and it does not reach the line afterwards where it sets that field to not have an error anymore.
I simply moved that line in this commit and that seemed to resolve it for me, doesn't happen on my Safari anymore.