### PR TITLE
Unify QR code options, append miic extension data at the end

### DIFF
--- a/src/ui/pages/Library.ts
+++ b/src/ui/pages/Library.ts
@@ -533,7 +533,7 @@ const miiColorConversionWarning = async (miiData: Mii) => {
   if (miiData.hasExtendedColors() === true) {
     let result = await Modal.prompt(
       "Warning",
-      "This Mii is using extended Switch colors that will be lost in the conversion to Wii U/3DS format. Are you sure you want to continue?",
+      "This Mii is using extended Switch colors, but those colors will never show up if you scan this QR Code anywhere outside of this app. Is this OK?",
       "body",
       false
     );
@@ -548,26 +548,15 @@ const miiExport = (mii: MiiLocalforage, miiData: Mii) => {
     "What would you like to do?",
     "body",
     {
-      text: "Generate Wii U/3DS compatible QR code",
+      text: "Generate QR code",
       async callback() {
         if (!(await miiColorConversionWarning(miiData))) return;
         // hack: force FFL shader for QR codes by changing the setting
         const setting = await getSetting("shaderType");
         await localforage.setItem("settings_shaderType", "wiiu");
-        const qrCodeImage = await QRCodeCanvas(mii.mii, false);
+        const qrCodeImage = await QRCodeCanvas(mii.mii, miiData.hasExtendedColors()); // extendedColors
         await localforage.setItem("settings_shaderType", setting);
-        downloadLink(qrCodeImage, `${miiData.miiName}_QR_ffsd.png`);
-      },
-    },
-    {
-      text: "Mii Creator QR code",
-      async callback() {
-        // hack: force FFL shader for QR codes by changing the setting
-        const setting = await getSetting("shaderType");
-        await localforage.setItem("settings_shaderType", "wiiu");
-        const qrCodeImage = await QRCodeCanvas(mii.mii, true);
-        await localforage.setItem("settings_shaderType", setting);
-        downloadLink(qrCodeImage, `${miiData.miiName}_QR_miic.png`);
+        downloadLink(qrCodeImage, `${miiData.miiName}_QR.png`);
       },
     },
     {

--- a/src/util/miiImageUtils.ts
+++ b/src/util/miiImageUtils.ts
@@ -21,20 +21,20 @@ const makeQrCodeImage = async (
 ): Promise<HTMLImageElement> => {
   let convertedVer3Data: Uint8Array, ver3QRData: any[];
 
-  if (extendedColors === true) {
-    convertedVer3Data = new Uint8Array(Buf.from(mii, "base64"));
-    ver3QRData = Array.from(convertedVer3Data);
-  } else {
-    convertedVer3Data = new Uint8Array(
-      convertDataToType(
-        new Uint8Array(Buf.from(mii, "base64")),
-        ver3Format,
-        ver3Format.className,
-        true
-      )
-    );
-    ver3QRData = encryptAndEncodeVer3StoreDataToQRCodeFormat(convertedVer3Data);
-  }
+  const miiU8 = new Uint8Array(Buf.from(mii, "base64"));
+  convertedVer3Data = new Uint8Array(
+    convertDataToType(
+      miiU8,
+      ver3Format,
+      ver3Format.className,
+      true
+    )
+  );
+  ver3QRData = encryptAndEncodeVer3StoreDataToQRCodeFormat(convertedVer3Data);
+  // Append any data after the first 96 bytes (fixed by the function above)
+  ver3QRData = new Uint8Array([...ver3QRData, ...miiU8.subarray(96)]); // May or may not append nothing.
+  // ... after the encrypted portion (appending after that should still be safe to scan)
+
   // console.log(convertedVer3Data, ver3QRData);
   const png = qrjs.generatePNG(ver3QRData, { margin: 0 });
   // //@ts-expect-error


### PR DESCRIPTION
This is a simple change to remove the separate miic QR option, in favor of just appending the extension data at the end of the encrypted 112 bytes in the QR code.

These codes have been verified to scan on Kaerutomo and my 3DS:
<img src="https://github.com/user-attachments/assets/fac8c965-655c-4127-bc19-353d3c91e772" height="600">

Raw data looks like this, miic data starting at 0x70 (112):
![image](https://github.com/user-attachments/assets/43bf72c9-4569-4b58-926e-1d451344ea9a)

Things you probably want to think about:
* Review the modal message I changed
<img src="https://github.com/user-attachments/assets/d222a7ce-0858-4f8b-997b-a52735f353f0" width="400">


* Whether or not "extendedColors" (basically just background atp) should be on or off - I made it based on `miiData.hasExtendedColors()`
* You going to add: extension name magic? checksum? Not just to the QR code but to miic itself?