### PR TITLE
arian nitpicks: make charinfo work on switch, do not show new update notice on first visit or iframe, enumerated body/shader types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Create and share Mii characters online with just a few clicks!
 
 ## Credits
 
-- A [fork](https://github.com/datkat21/FFL-Testing-with-hats) of the [mii-unsecure.ariankordi.net](https://mii-unsecure.ariankordi.net) API by [ariankordi](https://github.com/ariankordi), used to generate 3D Mii heads and renders.
-- `mii-js` library used for interacting with Mii data in a JavaScript-friendly way
-- [Some code](https://github.com/datkat21/mii-creator/tree/master/src/external/mii-frontend) "borrowed" from arian's website.
+- Uses a locally hosted version of the [mii-unsecure.ariankordi.net](https://mii-unsecure.ariankordi.net) [API](https://github.com/ariankordi/FFL-Testing/tree/renderer-server-prototype) by [ariankordi](https://github.com/ariankordi) used to generate 3D Mii heads and icons.
+  - A [fork](https://github.com/datkat21/FFL-Testing-with-hats) is used that adds hat support.
+- [mii-js](https://github.com/PretendoNetwork/mii-js) library used for interacting with Mii data in a JavaScript-friendly way
+- [Some utility code](https://github.com/datkat21/mii-creator/tree/master/src/external/mii-frontend) "borrowed" from arian's website for conversion, QR codes, etc.
 - Custom Mii Maker music by [objecty](https://x.com/objecty)
 
 ## Features
 
-This app uses a custom version of the FFSD data type that I call the MiiCreator format (.miic), allowing for custom colors and types from the Switch, while still allowing you to convert back to 3DS/Wii U.
+This app uses a custom, extended version of the FFSD Mii format that I call the MiiCreator format (.miic), allowing for extra colors and glasses from the Switch, while still allowing you to convert back to FFSD for 3DS/Wii U.
 
 - [x] Real 3D rendering unlike Mii Studio
 - [x] Change parts and colors of the Mii

--- a/src/class/3d/shader/ShaderUtils.ts
+++ b/src/class/3d/shader/ShaderUtils.ts
@@ -33,6 +33,7 @@ import {
   type DrawParamMaterial,
 } from "./SwitchShaderMaterials";
 import type Mii from "../../../external/mii-js/mii";
+import { ShaderType } from "../../../constants/BodyShaderTypes";
 import { getSetting } from "../../../util/SettingsHelper";
 import { miitomoFragmentShader, miitomoVertexShader } from "./MiitomoShader";
 
@@ -85,12 +86,12 @@ export async function traverseMesh(node: THREE.Mesh, mpCharInfo: Mii) {
   // reused for extra materials
   function modifyMaterialParam() {
     // Wii U shader modifiers
-    if (shaderSetting === "wiiu_blinn") {
+    if (shaderSetting === ShaderType.WiiUBlinn) {
       materialParam = { ...materialParam, ...FFLBlinnMaterial };
-    } else if (shaderSetting === "wiiu_gloss") {
+    } else if (shaderSetting === ShaderType.WiiUGloss) {
       materialParam = { ...materialParam, ...FFLGlossMaterial };
       lightDir = cLightDirGlossy;
-    } else if (shaderSetting === "wiiu_ffliconwithbody") {
+    } else if (shaderSetting === ShaderType.WiiUFFLIconWithBody) {
       lightDir = cLightDirFFLIconWithBody;
       lightAmbient = cLightAmbientFFLIconWithBody;
       lightDiffuse = cLightDiffuseFFLIconWithBody;
@@ -115,7 +116,7 @@ export async function traverseMesh(node: THREE.Mesh, mpCharInfo: Mii) {
   }
   THREE.ColorManagement.enabled = false;
 
-  if (shaderSetting === "none") {
+  if (shaderSetting === ShaderType.Simple) {
     THREE.ColorManagement.enabled = true;
 
     if (
@@ -182,7 +183,7 @@ export async function traverseMesh(node: THREE.Mesh, mpCharInfo: Mii) {
 
   let finalMat: THREE.Material;
 
-  if (shaderSetting === "switch") {
+  if (shaderSetting === ShaderType.Switch) {
     /* Do A LOTTA Calculations */
     let drawParamMaterial: DrawParamMaterial;
     let commonColor: number = 0; // failsafe common color set
@@ -524,7 +525,7 @@ export async function traverseMesh(node: THREE.Mesh, mpCharInfo: Mii) {
         alphaTest: originalMaterial.alphaTest, // Handle alpha testing
       });
     }
-  } else if (shaderSetting === "lightDisabled") {
+  } else if (shaderSetting === ShaderType.LightDisabled) {
     // it's easier to use the shader w/ lightEnable set to false for this
     // as MeshBasicMaterial is too bright
     finalMat = new THREE.ShaderMaterial({
@@ -556,7 +557,7 @@ export async function traverseMesh(node: THREE.Mesh, mpCharInfo: Mii) {
       transparent: originalMaterial.transparent, // Handle transparency
       alphaTest: originalMaterial.alphaTest, // Handle alpha testing
     });
-  } else if (shaderSetting === "miitomo") {
+  } else if (shaderSetting === ShaderType.Miitomo) {
     console.log("You are using Miitomo shader :)");
     finalMat = new THREE.ShaderMaterial({
       vertexShader: miitomoVertexShader,

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,11 +11,11 @@ const nnidFetchOrigin = "https://mii-unsecure.ariankordi.net";
 export const Config = {
   renderer: {
     baseURL,
-    renderFFLMakeIcon: `${baseURL}.png?shaderType=2&type=fflmakeicon&width=360&verifyCharInfo=0`,
-    renderHeadshotURL: `${baseURL}.png?shaderType=0&type=face&width=260&verifyCharInfo=0`,
+    renderFFLMakeIcon: `${baseURL}.png?shaderType=miitomo&type=fflmakeicon&width=360&verifyCharInfo=0`,
+    renderHeadshotURL: `${baseURL}.png?shaderType=wiiu&type=face&width=260&verifyCharInfo=0`,
     renderHeadshotURLNoParams: `${baseURL}.png`,
-    renderFullBodyURL: `${baseURL}.png?shaderType=0&type=all_body_sugar&width=420&verifyCharInfo=0&scale=1`,
-    render3DHeadURL: `${baseURL}.glb?shaderType=0&type=face&width=260&verifyCharInfo=0`,
+    renderFullBodyURL: `${baseURL}.png?shaderType=wiiu&type=all_body_sugar&width=420&verifyCharInfo=0&scale=1`,
+    render3DHeadURL: `${baseURL}.glb?shaderType=wiiu&type=face&width=260&verifyCharInfo=0`,
     renderFaceURL: `${baseURL}.png?scale=1&drawStageMode=mask_only&verifyCharInfo=0`,
   },
   dataFetch: {
@@ -98,35 +98,35 @@ export const Config = {
 
     <div class="flex-group" style="justify-content:flex-start">
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=080037030d020531020c030105040a0209000001000a011004010b0100662f04000214031603140d04000a020109&shaderType=1&width=96&source=update&characterYRotate=8&bodyType=2"> 
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=080037030d020531020c030105040a0209000001000a011004010b0100662f04000214031603140d04000a020109&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
         <div class="col" style="gap:12px;flex:1">
           <small>Arian <a href="https://github.com/ariankordi">(@ariankordi)</a></small>
           <div>Helped with implementing the new QR code feature and gave advice</div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3c4554575c616c6872818b909da0b1b7bec3cad0d78f93a1b1c0c78ce8f0f8fdf2f8f3f7ebebf6fdfcfffffb&shaderType=1&width=96&source=update&characterYRotate=8&bodyType=2"> 
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3c4554575c616c6872818b909da0b1b7bec3cad0d78f93a1b1c0c78ce8f0f8fdf2f8f3f7ebebf6fdfcfffffb&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
         <div class="col" style="gap:12px;flex:1">
           <small>Timothy <a href="https://github.com/Timiimiimii">(@Timimimi)</a></small>
           <div>Implemented the new <code>.charinfo</code> <a href="https://github.com/datkat21/mii-creator/pull/15">export format</a></div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3b3f3c4649555e5c6675777a7a7f7e818890979ea5b4b7bebbbac188bdc6ced4ccd6cccfe3f5f8fffcff0513&shaderType=1&width=96&source=update&characterYRotate=8&bodyType=2"> 
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3b3f3c4649555e5c6675777a7a7f7e818890979ea5b4b7bebbbac188bdc6ced4ccd6cccfe3f5f8fffcff0513&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
         <div class="col" style="gap:12px;flex:1">
           <small>obj <a href="https://x.com/objecty_twitt">(@objecty)</a></small>
           <div>Helped with designing some new icons</div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=0800450308040402020c0308060406020a0001000006000804000a0800326702010314031304190d04000a040109&shaderType=1&width=96&source=update&characterYRotate=8&bodyType=2"> 
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=0800450308040402020c0308060406020a0001000006000804000a0800326702010314031304190d04000a040109&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
         <div class="col" style="gap:12px;flex:1">
           <small>David J. <a href="https://x.com/dwyazzo90">(@dwyazzo90)</a></small>
           <div>Provided suggestions and ideas</div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e283208131d43484b524c515a5a606f75838a919ea5b4b7bebbb3ba8bced1d8e1fc03171d191b262d2e313745&shaderType=1&width=96&source=update&characterYRotate=8&bodyType=2"> 
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e283208131d43484b524c515a5a606f75838a919ea5b4b7bebbb3ba8bced1d8e1fc03171d191b262d2e313745&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
         <div class="col" style="gap:12px;flex:1">
           <small>justcamtro <a href="https://x.com/justcamtro">(@justcamtro)</a></small>
           <div>Tested the new update and gave feedback</div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,35 +98,35 @@ export const Config = {
 
     <div class="flex-group" style="justify-content:flex-start">
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=080037030d020531020c030105040a0209000001000a011004010b0100662f04000214031603140d04000a020109&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=080037030d020531020c030105040a0209000001000a011004010b0100662f04000214031603140d04000a020109&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=switch">
         <div class="col" style="gap:12px;flex:1">
           <small>Arian <a href="https://github.com/ariankordi">(@ariankordi)</a></small>
-          <div>Helped with implementing the new QR code feature and gave advice</div>
+          <div>Wrote code for the new QR code feature, helped with Git, debugging, advice</div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3c4554575c616c6872818b909da0b1b7bec3cad0d78f93a1b1c0c78ce8f0f8fdf2f8f3f7ebebf6fdfcfffffb&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3c4554575c616c6872818b909da0b1b7bec3cad0d78f93a1b1c0c78ce8f0f8fdf2f8f3f7ebebf6fdfcfffffb&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=switch">
         <div class="col" style="gap:12px;flex:1">
           <small>Timothy <a href="https://github.com/Timiimiimii">(@Timimimi)</a></small>
           <div>Implemented the new <code>.charinfo</code> <a href="https://github.com/datkat21/mii-creator/pull/15">export format</a></div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3b3f3c4649555e5c6675777a7a7f7e818890979ea5b4b7bebbbac188bdc6ced4ccd6cccfe3f5f8fffcff0513&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e3b3f3c4649555e5c6675777a7a7f7e818890979ea5b4b7bebbbac188bdc6ced4ccd6cccfe3f5f8fffcff0513&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=switch">
         <div class="col" style="gap:12px;flex:1">
           <small>obj <a href="https://x.com/objecty_twitt">(@objecty)</a></small>
           <div>Helped with designing some new icons</div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=0800450308040402020c0308060406020a0001000006000804000a0800326702010314031304190d04000a040109&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=0800450308040402020c0308060406020a0001000006000804000a0800326702010314031304190d04000a040109&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=switch">
         <div class="col" style="gap:12px;flex:1">
           <small>David J. <a href="https://x.com/dwyazzo90">(@dwyazzo90)</a></small>
           <div>Provided suggestions and ideas</div>
         </div>
       </div>
       <div class="flex-group" style="gap:0px;justify-content:flex-start">
-        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e283208131d43484b524c515a5a606f75838a919ea5b4b7bebbb3ba8bced1d8e1fc03171d191b262d2e313745&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=2">
+        <img draggable="false" width=96 height=96 src="${baseURL}.png?type=variableiconbody&data=00070e283208131d43484b524c515a5a606f75838a919ea5b4b7bebbb3ba8bced1d8e1fc03171d191b262d2e313745&shaderType=switch&width=96&source=update&characterYRotate=8&bodyType=switch">
         <div class="col" style="gap:12px;flex:1">
           <small>justcamtro <a href="https://x.com/justcamtro">(@justcamtro)</a></small>
           <div>Tested the new update and gave feedback</div>

--- a/src/constants/BodyShaderTypes.ts
+++ b/src/constants/BodyShaderTypes.ts
@@ -1,0 +1,47 @@
+// Types mapping to strings stored in settings
+// and sent to the backend renderer.
+
+export enum BodyType {
+  WiiU = "wiiu",
+  Switch = "switch",
+  Miitomo = "miitomo"
+};
+// All body types are supported by backend renderer for now
+
+export enum ShaderType {
+  WiiU = "wiiu",
+  Switch = "switch",
+  LightDisabled = "lightDisabled",
+  Simple = "none",
+  Miitomo = "miitomo",
+  WiiUBlinn = "wiiu_blinn",
+  WiiUFFLIconWithBody = "wiiu_ffliconwithbody" ,
+  WiiUGloss = "wiiu_gloss"
+}
+
+export function adjustShaderQuery(params: URLSearchParams, shader: ShaderType) {
+  switch(shader) {
+    case ShaderType.WiiU:
+    case ShaderType.Switch:
+    case ShaderType.Miitomo:
+      // share the same type string so can be used directly
+      params.set("shaderType", shader);
+      break;
+    case ShaderType.WiiUFFLIconWithBody:
+      params.set("shaderType", "ffliconwithbody");
+      break;
+    case ShaderType.WiiUGloss:
+      params.set("shaderType", "wiiu");
+      break;
+    case ShaderType.WiiUBlinn:
+    case ShaderType.Simple:
+      params.set("shaderType", "wiiu_blinn");
+      break;
+    case ShaderType.LightDisabled:
+      params.set("shaderType", "wiiu");
+      params.set("lightEnable", "0");
+      break;
+    default:
+      console.warn(`unknown shader type: ${shader}`);
+  }
+}

--- a/src/external/mii-frontend/data-conversion.js
+++ b/src/external/mii-frontend/data-conversion.js
@@ -644,7 +644,7 @@ const switchCharInfoHex = [...switchCharInfoData].map(byteToHex).join('');
       // texture which will look wrong here
       // so just remove it in order to avoid
       // ppl who use that and don't know that
-      .replace("&shaderType=1", "")
+      .replace("&shaderType=switch", "")
       .replace(".png?", ".glb?");
     modelDownloadButtons[0].setAttribute(
       "action", // actually a form lmao

--- a/src/external/mii-js/mii.ts
+++ b/src/external/mii-js/mii.ts
@@ -1364,7 +1364,7 @@ export default class Mii {
       ...STUDIO_RENDER_DEFAULTS,
       ...queryParams,
       data: this.encodeStudio().toString("hex"),
-      shaderType: 0,
+      shaderType: "default",
     };
 
     let fileExt = "png";

--- a/src/external/mii-js/mii.ts
+++ b/src/external/mii-js/mii.ts
@@ -1227,43 +1227,37 @@ export default class Mii {
     return miiStudioData;
   }
 
-  // CharInfo (Switch) encoding function courtesy of Timimimi
-  public encodeCharinfo(): Buffer {
+  // Encoding for Switch CharInfo (nn::mii::CharInfo) format
+  // Originally implemented by Timiimiimii: https://github.com/Timiimiimii
+  public encodeCharInfoSwitch(): Buffer {
     this.validate(); // * Don't write invalid Mii data
 
     // TODO - Maybe create a new stream instead of modifying the original?
     this.bitStream.bitSeek(0);
 
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    this.bitStream.writeUint8(RandomInt(255));
-    //listen idk what those are and im testing this
+    // Write createID field (nn::mii::CreateId).
+    for (let i = 0; i < 16; i++) { // UUIDv4 length
+      let r = RandomInt(255);
+      if (i == 8) { // If this is the 8th field...
+        // Set bits checked by nn::mii::CreateId::IsValid() on Switch
+        r &= 0b00111111; r |= 0b10000000;
+      }
+      this.bitStream.writeUint8(r); // Write
+    }
+
     this.bitStream.writeUTF16String(this.miiName);
 
-    this.bitStream.writeUint8(0);
-    this.bitStream.writeUint8(0);
-    this.bitStream.writeUint8(0);
-    // i mean. it works but.
+    this.bitStream.writeUint8(0); // Padding for name
+    this.bitStream.writeUint8(this.characterSet);
+    this.bitStream.writeUint8(0); // ???
 
     this.bitStream.writeUint8(this.favoriteColor);
     this.bitStream.writeUint8(this.gender);
     this.bitStream.writeUint8(this.height);
     this.bitStream.writeUint8(this.build);
-    this.bitStream.writeUint8(this.normalMii);
-    this.bitStream.writeUint8(this.regionLock); //region move? idk im putting this in now
+    // type field - 0 = normal, 1 = special, inverse
+    this.bitStream.writeUint8(!this.normalMii);
+    this.bitStream.writeUint8(this.regionLock);
 
     this.bitStream.writeUint8(this.faceType);
     this.bitStream.writeUint8(this.trueSkinColor);
@@ -1337,9 +1331,8 @@ export default class Mii {
     this.bitStream.writeUint8(this.moleXPosition);
     this.bitStream.writeUint8(this.moleYPosition);
 
-    this.bitStream.writeUint8(0); //always zero
+    this.bitStream.writeUint8(0); // Always zero.
 
-    // pray that this flarking works
     return Buffer.from(this.bitStream.view._view).slice(0, 0x58);
   }
 

--- a/src/l10n/manager.ts
+++ b/src/l10n/manager.ts
@@ -1,28 +1,45 @@
 // Adapted from my language manager used in Cherry Tree TV
 import localforage from "localforage";
 
-let lang = (await localforage.getItem("settings_language")) || "en_US";
+const langValue = await localforage.getItem("language");
+let lang = langValue || "en_US";
 let strings: Record<string, any> = {};
 
 export const langList = ["en_US"];
 
-try {
-  let languageModule = (await import(`./lang/${lang}.js`)).default;
-  localforage.setItem("language", lang);
-  strings = languageModule;
-} catch (e) {
-  console.log("error");
+async function setLanguage(lang: string, isFirst: boolean) {
+  if (isFirst) { // call when page first opens?
+    // HACK: get value of language since it
+    // is always set and use as indicator
+    // if this is the user's first visit.
+    //@ts-expect-error
+    window.firstVisit = langValue === null; // bool
+  }
+  // initialize the key to default
+  if (isFirst && langValue === null) {
+      await localforage.setItem("language", lang);
+  }
+
+  try {
+    // this will fail if the lang doesn't exist:
+    let languageModule = (await import(`./${lang}.js`)).default;
+    if (isFirst) {
+      // do not await on first set
+      localforage.setItem("language", lang);
+    } else {
+      await localforage.setItem("language", lang);
+    }
+    strings = languageModule;
+  } catch (e) {
+    console.log("Failed to load strings!");
+  }
 }
+
+await setLanguage(lang, true); // isFirst = true
 
 export const langManager = {
   async setLanguage(lang: string) {
-    try {
-      let languageModule = (await import(`./${lang}.js`)).default;
-      await localforage.setItem("language", lang);
-      strings = languageModule;
-    } catch (e) {
-      console.log("Failed to load strings!");
-    }
+    setLanguage(lang, false); // isFirst = false
   },
   getLanguage() {
     return lang;

--- a/src/ui/pages/Library.ts
+++ b/src/ui/pages/Library.ts
@@ -71,23 +71,23 @@ export const miiIconUrl = (
   switch (currentShader) {
     case "wiiu":
     case "wiiu_gloss":
-      params.set("shaderType", "0");
+      params.set("shaderType", "wiiu");
       break;
     case "none":
     case "wiiu_blinn":
-      params.set("shaderType", "3");
+      params.set("shaderType", "wiiu_blinn");
       break;
     case "wiiu_ffliconwithbody":
-      params.set("shaderType", "4");
+      params.set("shaderType", "ffliconwithbody");
       break;
     case "switch":
-      params.set("shaderType", "1");
+      params.set("shaderType", "switch");
       break;
     case "miitomo":
-      params.set("shaderType", "2");
+      params.set("shaderType", "miitomo");
       break;
     case "lightDisabled":
-      params.set("shaderType", "0");
+      params.set("shaderType", "wiiu");
       params.set("lightEnable", "0");
       break;
   }

--- a/src/ui/pages/Library.ts
+++ b/src/ui/pages/Library.ts
@@ -1597,7 +1597,7 @@ const miiExportDownload = async (mii: MiiLocalforage, miiData: Mii) => {
             text: "Download CharInfo (Switch) file",
             async callback() {
               //if (!(await miiColorConversionWarning(miiData))) return;
-              const blob = new Blob([miiData.encodeCharinfo()]);
+              const blob = new Blob([miiData.encodeCharInfoSwitch()]);
               const url = URL.createObjectURL(blob);
 
               const a = document.createElement("a");
@@ -1655,7 +1655,7 @@ const miiExportDownload = async (mii: MiiLocalforage, miiData: Mii) => {
               new Html("span").class("h4").text("CharInfo (Switch) data (Hex)"),
               new Html("pre")
                 .class("pre-wrap", "mb-0")
-                .text(miiData.encodeCharinfo().toString("hex"))
+                .text(miiData.encodeCharInfoSwitch().toString("hex"))
             ),
             new Html("div").appendMany(
               new Html("span").class("h4").text("MiiC (Base64)"),

--- a/src/ui/pages/Library.ts
+++ b/src/ui/pages/Library.ts
@@ -41,6 +41,7 @@ import { MiiFavoriteColorIconTable } from "../../constants/ColorTables";
 import { getString as _ } from "../../l10n/manager";
 import { FFLiDatabaseRandom_Get } from "../../external/ffl/FFLiDatabaseRandom";
 import { replayUpdateNotice, Settings } from "./Settings";
+import { adjustShaderQuery, ShaderType, BodyType } from "../../constants/BodyShaderTypes";
 import { getSetting } from "../../util/SettingsHelper";
 import { GLTFExporter } from "three/examples/jsm/Addons.js";
 import {
@@ -68,29 +69,8 @@ export const miiIconUrl = (
   let params = new URLSearchParams();
 
   params.set("data", mii.encodeStudio().toString("hex"));
-  switch (currentShader) {
-    case "wiiu":
-    case "wiiu_gloss":
-      params.set("shaderType", "wiiu");
-      break;
-    case "none":
-    case "wiiu_blinn":
-      params.set("shaderType", "wiiu_blinn");
-      break;
-    case "wiiu_ffliconwithbody":
-      params.set("shaderType", "ffliconwithbody");
-      break;
-    case "switch":
-      params.set("shaderType", "switch");
-      break;
-    case "miitomo":
-      params.set("shaderType", "miitomo");
-      break;
-    case "lightDisabled":
-      params.set("shaderType", "wiiu");
-      params.set("lightEnable", "0");
-      break;
-  }
+  // set shader type in query params
+  adjustShaderQuery(params, currentShader);
   params.set("bodyType", currentBodyModel);
   params.set("type", view);
   params.set("width", width.toString());
@@ -126,11 +106,11 @@ export const miiIconUrl = (
   return `${url}?${params.toString()}`;
 };
 
-let currentShader: string = "wiiu";
+let currentShader: ShaderType = ShaderType.WiiU;
 document.addEventListener("library-shader-update", async () => {
   currentShader = await getSetting("shaderType");
 });
-let currentBodyModel: string = "wiiu";
+let currentBodyModel: BodyType = BodyType.WiiU;
 document.addEventListener("library-body-update", async () => {
   currentBodyModel = await getSetting("bodyModel");
 });

--- a/src/ui/pages/SelectionLibrary.ts
+++ b/src/ui/pages/SelectionLibrary.ts
@@ -21,7 +21,7 @@ export const newMiiId = async () =>
 export const miiIconUrl = (mii: Mii) =>
   `${Config.renderer.renderHeadshotURLNoParams}?data=${mii
     .encodeStudio()
-    .toString("hex")}&shaderType=0&type=face&width=180&verifyCharInfo=0`;
+    .toString("hex")}&shaderType=wiiu&type=face&width=180&verifyCharInfo=0`;
 
 export function SelectionLibrary(highlightMiiId?: string): Promise<Mii> {
   return new Promise(async (resolve, reject) => {

--- a/src/ui/pages/Settings.ts
+++ b/src/ui/pages/Settings.ts
@@ -5,6 +5,7 @@ import localforage from "localforage";
 import { getMusicManager } from "../../class/audio/MusicManager";
 import { getSoundManager } from "../../class/audio/SoundManager";
 import { getSetting, setSetting } from "../../util/SettingsHelper";
+import { adjustShaderQuery, ShaderType, BodyType } from "../../constants/BodyShaderTypes";
 import { Config } from "../../config";
 
 export const updateSettings = async (force: boolean = false) => {
@@ -63,30 +64,8 @@ export const updateSettings = async (force: boolean = false) => {
         params.delete("shaderType");
         params.delete("lightEnable");
 
-        // TODO: probably shouldn't hard-code this and it should be a constant lookup table or something
-        switch (currentShader) {
-          case "wiiu":
-          case "wiiu_gloss":
-            params.set("shaderType", "wiiu");
-            break;
-          case "none":
-          case "wiiu_blinn":
-            params.set("shaderType", "wiiu_blinn");
-            break;
-          case "wiiu_ffliconwithbody":
-            params.set("shaderType", "ffliconwithbody");
-            break;
-          case "switch":
-            params.set("shaderType", "switch");
-            break;
-          case "miitomo":
-            params.set("shaderType", "miitomo");
-            break;
-          case "lightDisabled":
-            params.set("shaderType", "wiiu");
-            params.set("lightEnable", "0");
-            break;
-        }
+        // set shader type in query params
+        adjustShaderQuery(params, currentShader);
 
         if (sourceToUpdate === "src") {
           image.src = `${source.split("?")[0]}?${params.toString()}`;
@@ -114,19 +93,8 @@ export const updateSettings = async (force: boolean = false) => {
 
         params.delete("bodyType");
 
-        // TODO: probably shouldn't hard-code this and it should be a constant lookup table or something
-        switch (bodyType) {
-          case "wiiu":
-          case "lightDisabled":
-            params.set("bodyType", "0");
-            break;
-          case "switch":
-            params.set("bodyType", "1");
-            break;
-          case "miitomo":
-            params.set("bodyType", "2");
-            break;
-        }
+        // assuming the bodyType string is supported on the server
+        params.set("bodyType", bodyType);
 
         if (sourceToUpdate === "src") {
           image.src = `${source.split("?")[0]}?${params.toString()}`;
@@ -206,16 +174,16 @@ export const settingsInfo: Record<string, any> = {
     label: "Shader Type",
     description:
       "Sorry that most of the shaders are not yet ready for use.\nUsing the Simple shader brings back the old simplistic Mii Creator lighting from the early days.\n* Does not apply to 2D mode.",
-    default: "wiiu",
+    default: ShaderType.WiiU,
     choices: [
-      { label: "No Lighting", value: "lightDisabled" },
-      { label: "Simple", value: "none" },
-      { label: "Glossy", value: "wiiu_gloss" },
-      { label: "Wii U (Default)", value: "wiiu" },
-      { label: "Wii U (Blinn)", value: "wiiu_blinn" },
-      { label: "Wii U (Alt)", value: "wiiu_ffliconwithbody" },
-      { label: "Switch (WIP)", value: "switch", disabled: true },
-      { label: "Miitomo (WIP)", value: "miitomo", disabled: true },
+      { label: "No Lighting", value: ShaderType.LightDisabled },
+      { label: "Simple", value: ShaderType.Simple },
+      { label: "Glossy", value: ShaderType.WiiUGloss },
+      { label: "Wii U (Default)", value: ShaderType.WiiU },
+      { label: "Wii U (Blinn)", value: ShaderType.WiiUBlinn },
+      { label: "Wii U (Alt)", value: ShaderType.WiiUFFLIconWithBody },
+      { label: "Switch (WIP)", value: ShaderType.Switch, disabled: true },
+      { label: "Miitomo (WIP)", value: ShaderType.Miitomo, disabled: true },
     ],
   },
   bodyModel: {
@@ -223,11 +191,11 @@ export const settingsInfo: Record<string, any> = {
     label: "Body Model",
     description:
       "Pose selections are different depending on the body model you use.\n* Does not apply to 2D mode.",
-    default: "wiiu",
+    default: ShaderType.WiiU,
     choices: [
-      { label: "Wii U (default)", value: "wiiu" },
-      { label: "Switch", value: "switch", disabled: true },
-      { label: "Miitomo", value: "miitomo" },
+      { label: "Wii U (default)", value: BodyType.WiiU },
+      { label: "Switch", value: BodyType.WiiU, disabled: true },
+      { label: "Miitomo", value: BodyType.Miitomo },
     ],
   },
   bodyModelHands: {

--- a/src/ui/pages/Settings.ts
+++ b/src/ui/pages/Settings.ts
@@ -553,7 +553,7 @@ export async function displayUpdateNotice() {
     && notSeenLatest;
 
   //@ts-expect-error
-  console.log(`seenLatest: ${seenLatest}\nfirstVisit: ${window.firstVisit}\nshould see update notice?: ${shouldSeeNotice}`);
+  console.log(`notSeenLatest: ${notSeenLatest}\nfirstVisit: ${window.firstVisit}\nshould see update notice?: ${shouldSeeNotice}`);
 
   //@ts-expect-error
   if (window.firstVisit && !isInIframe) {

--- a/src/ui/pages/Settings.ts
+++ b/src/ui/pages/Settings.ts
@@ -567,14 +567,34 @@ export async function replayUpdateNotice() {
 }
 
 export async function displayUpdateNotice() {
-  const hasSeenLatestUpdate = await getSetting(
-    `has-seen-${Config.version.string}`
-  );
-  console.log(hasSeenLatestUpdate);
-  if (hasSeenLatestUpdate === false || hasSeenLatestUpdate === null) {
+  const seenKey = `has-seen-${Config.version.string}`;
+  const seenValue = await getSetting(seenKey);
+  const notSeenLatest = (seenValue === false || seenValue === null);
+
+  // https://stackoverflow.com/a/326076
+  const isInIframe = window.self !== window.top;
+
+  // Should the user see the update popup?
+  const shouldSeeNotice =
+    // Do not show to first time users
+    //@ts-expect-error
+    !window.firstVisit // NOTE: src/l10n/manager.ts
+    // undefined = l10n manager did not run?, false = language key is null (never ran site)
+    && !isInIframe // Do not show to API users
+    // Show if has-seen key doesn't exist
+    && notSeenLatest;
+
+  //@ts-expect-error
+  console.log(`seenLatest: ${seenLatest}\nfirstVisit: ${window.firstVisit}\nshould see update notice?: ${shouldSeeNotice}`);
+
+  //@ts-expect-error
+  if (window.firstVisit && !isInIframe) {
+    // First time? You have "seen" the current version
+    await setSetting(seenKey, true);
+  } else if (shouldSeeNotice) {
     let m = Modal.modal(
       `New Update: ${Config.version.string}`,
-      "Yes new update",
+      "Yes new update", // placeholder will be replaced
       "body",
       {
         text: "OK",

--- a/src/ui/pages/Settings.ts
+++ b/src/ui/pages/Settings.ts
@@ -67,23 +67,23 @@ export const updateSettings = async (force: boolean = false) => {
         switch (currentShader) {
           case "wiiu":
           case "wiiu_gloss":
-            params.set("shaderType", "0");
+            params.set("shaderType", "wiiu");
             break;
           case "none":
           case "wiiu_blinn":
-            params.set("shaderType", "3");
+            params.set("shaderType", "wiiu_blinn");
             break;
           case "wiiu_ffliconwithbody":
-            params.set("shaderType", "4");
+            params.set("shaderType", "ffliconwithbody");
             break;
           case "switch":
-            params.set("shaderType", "1");
+            params.set("shaderType", "switch");
             break;
           case "miitomo":
-            params.set("shaderType", "2");
+            params.set("shaderType", "miitomo");
             break;
           case "lightDisabled":
-            params.set("shaderType", "0");
+            params.set("shaderType", "wiiu");
             params.set("lightEnable", "0");
             break;
         }

--- a/src/util/miiImageUtils.ts
+++ b/src/util/miiImageUtils.ts
@@ -263,7 +263,7 @@ export function createMiiCard(
             Config.renderer.renderHeadshotURLNoParams +
             `?data=${encodeURIComponent(
               studioData
-            )}&type=variableiconbody&verifyCharInfo=0&shaderType=1&width=96&source=credits&characterYRotate=8&bodyType=2&` +
+            )}&type=variableiconbody&verifyCharInfo=0&shaderType=switch&width=96&source=credits&characterYRotate=8&bodyType=2&` +
             extra,
         })
         .style({ width: "96px", height: "96px" }),

--- a/src/util/miiImageUtils.ts
+++ b/src/util/miiImageUtils.ts
@@ -263,7 +263,7 @@ export function createMiiCard(
             Config.renderer.renderHeadshotURLNoParams +
             `?data=${encodeURIComponent(
               studioData
-            )}&type=variableiconbody&verifyCharInfo=0&shaderType=switch&width=96&source=credits&characterYRotate=8&bodyType=2&` +
+            )}&type=variableiconbody&verifyCharInfo=0&shaderType=switch&width=96&source=credits&characterYRotate=8&bodyType=switch&` +
             extra,
         })
         .style({ width: "96px", height: "96px" }),


### PR DESCRIPTION
* make charinfo work on switch
  - by adding minor corrections to create id generation and the "normalMii" type field
  - also renamed it "CharInfo (Switch)" but you already did so you will see redundant changes here
  - works on NintendoSDK, assuming it will also import to miiport and work injected into games and such
* do not show new update notice on first visit or iframe
  - this is using the "language" localforage key, if it doesn't exist, to judge whether or not it's your first visit - which is pretty consistently set in my experience
  - it also forces language to be consistently made every time and makes the l10n manager store some global in window but you're already doing this so not tooo worried about it
  - there's some code to try to detect if you're in an iframe which is from stack overflow but mostly untested
* body and shader types sent as strings to the server
  - mii studio never used ints as enums, just strings, so i feel it's more natural for my service to do the same and it recently started supporting string enums for body/shader types so this change does that
* enumerated body and shader types
  - then there's a function to set query param based on the shader type, think that's better than a table considering no lighting needs a separate param toooooooooooooooo hhhhhhhhhhhhhhhhhhhh
* snuck in a minor revision to my credit and to the readme 

felt like getting to but didn't:
* update query params for my headwear implementation: headwearIndex/headwearColor
  - needs coordination on your part/to do this on your own accord
  - clarified that your fork only adds hats in the readme instead
* Wii U (Alt) -> Wii U (Bright) and then rename "Wii U (Glossy)" to "Toon"? or something?
  - don't feel that Glossy makes any sense but    i think both are smth we will change on our own

feel free to test and reject any parts of this thanks